### PR TITLE
Added models support and constructor with arguments in EntityCollectionMappingFilter and EntityMappingFilter

### DIFF
--- a/src/Mapper/FieldFilter/EntityCollectionMappingFilter.php
+++ b/src/Mapper/FieldFilter/EntityCollectionMappingFilter.php
@@ -14,6 +14,7 @@ class EntityCollectionMappingFilter extends AbstractMappingFilter
         string $className,
         protected EntityManagerInterface $em,
         protected bool $canExistsEntity = false,
+        private ?\Closure $classBuilder = null,
     ) {
         parent::__construct($className);
     }
@@ -44,7 +45,7 @@ class EntityCollectionMappingFilter extends AbstractMappingFilter
         }
         unset($item);
 
-        $objectFilter = new EntityMappingFilter($this->className, $this->em);
+        $objectFilter = new EntityMappingFilter($this->className, $this->em, $this->classBuilder);
         $objectFilter->setMapper($this->getMapper());
 
         $values = array_map(fn ($item) => $objectFilter->filter($item), $value);

--- a/src/Mapper/FieldFilter/EntityCollectionMappingFilter.php
+++ b/src/Mapper/FieldFilter/EntityCollectionMappingFilter.php
@@ -38,8 +38,15 @@ class EntityCollectionMappingFilter extends AbstractMappingFilter
 
         $removedIds = [];
         foreach ($value as $key => $item) {
-            if (isset($item['id'], $item['deleted']) && $item['deleted']) {
+            if (is_array($item) && isset($item['id'], $item['deleted']) && $item['deleted']) {
                 $removedIds[] = (int) $item['id'];
+                unset($value[$key]);
+            }
+            if (is_object($item)
+                && property_exists($item, 'id') && $item->id
+                && property_exists($item, 'deleted') && $item->deleted
+            ) {
+                $removedIds[] = (int) $item->id;
                 unset($value[$key]);
             }
         }

--- a/src/Mapper/FieldFilter/EntityMappingFilter.php
+++ b/src/Mapper/FieldFilter/EntityMappingFilter.php
@@ -14,6 +14,7 @@ class EntityMappingFilter extends AbstractMappingFilter
     public function __construct(
         string $className,
         protected EntityManagerInterface $em,
+        private ?\Closure $classBuilder = null,
     ) {
         parent::__construct($className);
     }
@@ -27,6 +28,10 @@ class EntityMappingFilter extends AbstractMappingFilter
         $entity = null;
         if (isset($value['id'])) {
             $entity = $this->em->getRepository($this->className)->find($value['id']);
+        }
+
+        if (!$entity && null !== $this->classBuilder) {
+            $entity = $this->classBuilder->call($this, $value);
         }
 
         return $this->getMapper()->map($value, $entity ?: $this->className);

--- a/src/Mapper/FieldFilter/EntityMappingFilter.php
+++ b/src/Mapper/FieldFilter/EntityMappingFilter.php
@@ -26,8 +26,11 @@ class EntityMappingFilter extends AbstractMappingFilter
         }
 
         $entity = null;
-        if (isset($value['id'])) {
+        if (is_array($value) && isset($value['id'])) {
             $entity = $this->em->getRepository($this->className)->find($value['id']);
+        }
+        if (is_object($value) && property_exists($value, 'id') && $value->id) {
+            $entity = $this->em->getRepository($this->className)->find($value->id);
         }
 
         if (!$entity && null !== $this->classBuilder) {


### PR DESCRIPTION
EntityCollectionMappingFilter and EntityMappingFilter now can be used on classes with required arguments in constructor by using classBuilder closure.
Objects are now supported in EntityCollectionMappingFilter and EntityMappingFilter